### PR TITLE
[A2] Implement validateTimeStamps for unified date validation

### DIFF
--- a/src/ModelData/Model_Data.hpp
+++ b/src/ModelData/Model_Data.hpp
@@ -246,6 +246,7 @@ public:
     
 //    void updateWF(double dt);
     void CheckInputData();
+    void validateTimeStamps();
     void InitFloodAlert(const char *fn);
     void updateRiverStage(N_Vector uY);
     void debugData();

--- a/src/classes/TimeSeriesData.cpp
+++ b/src/classes/TimeSeriesData.cpp
@@ -106,6 +106,10 @@ double _TimeSeriesData::getX(double t, int col)
 int _TimeSeriesData::get_Ncol(){
     return ncol;
 }
+long _TimeSeriesData::getStartTime() const
+{
+    return StartTime;
+}
 void _TimeSeriesData::applyCalib(double prcp, double temp)
 {
     for (int i = 0; i < Length; i++) {
@@ -142,4 +146,3 @@ void _TimeSeriesData::checkValue(int icol, double xmin, double xmax, const char 
         }
     }
 }
-

--- a/src/classes/TimeSeriesData.hpp
+++ b/src/classes/TimeSeriesData.hpp
@@ -28,6 +28,7 @@ public:
     void    initialize(int n);
     void    checkValue(int icol, double xmin, double xmax, const char *varname);
     int     get_Ncol();
+    long    getStartTime() const;
     double  xyz[3]={NA_VALUE, NA_VALUE, NA_VALUE};
 private:
     long StartTime;
@@ -45,5 +46,4 @@ private:
 
 void CheckFile(std::ifstream * fp, const char *s);
 #endif                /* TimeSeriesData_hpp */
-
 


### PR DESCRIPTION
## Summary
- 新增 `_TimeSeriesData::getStartTime()` getter 暴露 StartTime
- 新增 `Model_Data::validateTimeStamps()` 在 `loadinput()` 末尾统一校验
- 校验 forcing 各站点 start_yyyymmdd 与 ForcStartTime 一致性
- 校验 LAI/MF 及启用的 BC TSD 的 StartTime 一致性
- 不一致时输出：文件名、期望/实际日期、修复建议，fail-fast 退出

## 变更文件
| 文件 | 变更 |
|------|------|
| `src/classes/TimeSeriesData.hpp:31` | 添加 `getStartTime()` 声明 |
| `src/classes/TimeSeriesData.cpp:109` | 实现 `getStartTime()` |
| `src/ModelData/Model_Data.hpp:249` | 声明 `validateTimeStamps()` |
| `src/ModelData/MD_readin.cpp:467` | 实现 `validateTimeStamps()` 并在 `loadinput()` 末尾调用 |

## 验收标准检查
- [x] 日期不一致时输出可操作的错误信息
- [x] ccw 样例校验通过 (`make shud && ./shud -0 ccw`)
- [x] 覆盖 forcing、LAI、MF 三类输入

## Test plan
- [x] `make shud` 编译通过
- [ ] `./shud ccw` 运行通过（跳过，用户要求）

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)