### PR TITLE
feat(A3): implement time monotonicity and coverage pre-check (fail-fast)

### DIFF
--- a/src/ModelData/MD_readin.cpp
+++ b/src/ModelData/MD_readin.cpp
@@ -478,6 +478,42 @@ void Model_Data::validateTimeStamps()
         myexit(ERRDATAIN);
     }
 
+    // 0) fail-fast: forcing must cover simulation period [CS.StartTime, CS.EndTime]
+    const double simStart = CS.StartTime;
+    const double simEnd = CS.EndTime;
+    if (simEnd + 1e-12 < simStart) {
+        fprintf(stderr, "\n  Fatal Error: Invalid simulation period (CS.StartTime > CS.EndTime).\n");
+        fprintf(stderr, "  CS.StartTime = %.3f min (%.6f day)\n", simStart, simStart / 1440.0);
+        fprintf(stderr, "  CS.EndTime   = %.3f min (%.6f day)\n", simEnd, simEnd / 1440.0);
+        fprintf(stderr, "  Fix: check START/END in %s\n", pf_in->file_para);
+        myexit(ERRDATAIN);
+    }
+    for (int i = 0; i < NumForc; i++) {
+        const double forcMin = tsd_weather[i].getMinTime();
+        const double forcMax = tsd_weather[i].getMaxTime();
+
+        const bool startCovered = (forcMin - simStart) <= 1e-6;
+        const bool endCovered = (simEnd - forcMax) <= 1e-6;
+        if (!startCovered || !endCovered) {
+            fprintf(stderr, "\n  Fatal Error: Forcing data coverage is insufficient for simulation.\n");
+            fprintf(stderr, "  File: %s\n", tsd_weather[i].fn.c_str());
+            fprintf(stderr, "  Simulation interval: [%.3f, %.3f] min ([%.6f, %.6f] day)\n",
+                    simStart, simEnd, simStart / 1440.0, simEnd / 1440.0);
+            fprintf(stderr, "  Forcing coverage:    [%.3f, %.3f] min ([%.6f, %.6f] day)\n",
+                    forcMin, forcMax, forcMin / 1440.0, forcMax / 1440.0);
+            if (!startCovered) {
+                fprintf(stderr, "  Issue: forcing starts AFTER simulation START.\n");
+            }
+            if (!endCovered) {
+                fprintf(stderr, "  Issue: forcing ends BEFORE simulation END.\n");
+            }
+            fprintf(stderr, "  Fix suggestions:\n");
+            fprintf(stderr, "    - Extend the forcing time-series (%s) to cover the simulation period.\n", tsd_weather[i].fn.c_str());
+            fprintf(stderr, "    - Or adjust START/END in %s to fit within forcing coverage.\n", pf_in->file_para);
+            myexit(ERRDATAIN);
+        }
+    }
+
     // 1) forcing: station file start_yyyymmdd == ForcStartTime
     for (int i = 0; i < NumForc; i++) {
         const std::string &filename = tsd_weather[i].fn;

--- a/src/classes/TimeSeriesData.cpp
+++ b/src/classes/TimeSeriesData.cpp
@@ -1,17 +1,21 @@
 #include <iostream>
 #include <stdio.h>
 #include <stdlib.h>
+#include <limits>
 #include "TimeSeriesData.hpp"
 
 void CheckFile(std::ifstream * fp, const char *s)
 {
-    if (fp == NULL) {
+    if (fp == NULL || !fp->is_open()) {
         fprintf(stderr, "\n  Fatal Error: \n %s is in use or does not exist!\n", s);
         myexit(ERRFileIO);
     }
 }
 
 _TimeSeriesData::_TimeSeriesData(){
+    timeRangeCached = 0;
+    minTime = NA_VALUE;
+    maxTime = NA_VALUE;
 }
 
 _TimeSeriesData::~_TimeSeriesData(){
@@ -30,6 +34,9 @@ void _TimeSeriesData::initialize(int n)
     iNow = 0;
     nQue = 0;
     eof = 0;
+    timeRangeCached = 0;
+    minTime = NA_VALUE;
+    maxTime = NA_VALUE;
     for (int i = 0; i < MAXQUE + 1; i++) {
         pRing[i] = i + 1;
     }
@@ -42,9 +49,108 @@ void _TimeSeriesData::initialize(int n)
         ts[i] = new double[n];
     }
 }
+
+void _TimeSeriesData::computeTimeRange() const
+{
+    if (timeRangeCached) {
+        return;
+    }
+
+    std::ifstream file(fn);
+    CheckFile(&file, fn.c_str());
+
+    std::string line;
+    if (!std::getline(file, line)) {
+        fprintf(stderr, "\n  Fatal Error: Empty time-series file.\n");
+        fprintf(stderr, "  File: %s\n", fn.c_str());
+        myexit(ERRFileIO);
+    }
+    if (!std::getline(file, line)) {
+        fprintf(stderr, "\n  Fatal Error: Missing header line in time-series file.\n");
+        fprintf(stderr, "  File: %s\n", fn.c_str());
+        myexit(ERRFileIO);
+    }
+
+    bool hasData = false;
+    double prevTimeMin = 0.0;
+    long prevLineNo = 0;
+    long lineNo = 2; // already consumed 2 lines
+
+    double localMin = std::numeric_limits<double>::infinity();
+    double localMax = -std::numeric_limits<double>::infinity();
+
+    while (std::getline(file, line)) {
+        lineNo++;
+        const size_t first = line.find_first_not_of(" \t\r\n");
+        if (first == std::string::npos || line[first] == '#') {
+            continue;
+        }
+
+        std::istringstream iss(line);
+        double timeDay = 0.0;
+        if (!(iss >> timeDay)) {
+            fprintf(stderr, "\n  Fatal Error: Failed to parse time value.\n");
+            fprintf(stderr, "  File: %s\n", fn.c_str());
+            fprintf(stderr, "  Line: %ld\n", lineNo);
+            fprintf(stderr, "  Content: %s\n", line.c_str());
+            myexit(ERRDATAIN);
+        }
+        const double timeMin = timeDay * 1440.0; // Day -> minute
+
+        if (!hasData) {
+            hasData = true;
+            prevTimeMin = timeMin;
+            prevLineNo = lineNo;
+            localMin = timeMin;
+            localMax = timeMin;
+            continue;
+        }
+
+        if (timeMin + 1e-12 < prevTimeMin) {
+            fprintf(stderr, "\n  Fatal Error: Time column is not monotonic non-decreasing.\n");
+            fprintf(stderr, "  File: %s\n", fn.c_str());
+            fprintf(stderr, "  Previous line: %ld, time = %.15g day (%.3f min)\n",
+                    prevLineNo, prevTimeMin / 1440.0, prevTimeMin);
+            fprintf(stderr, "  Current  line: %ld, time = %.15g day (%.3f min)\n",
+                    lineNo, timeMin / 1440.0, timeMin);
+            fprintf(stderr, "  Fix: sort the time column ascending (allow equal), or regenerate the file.\n");
+            myexit(ERRDATAIN);
+        }
+
+        if (timeMin < localMin) localMin = timeMin;
+        if (timeMin > localMax) localMax = timeMin;
+        prevTimeMin = timeMin;
+        prevLineNo = lineNo;
+    }
+
+    if (!hasData) {
+        fprintf(stderr, "\n  Fatal Error: No data rows in time-series file.\n");
+        fprintf(stderr, "  File: %s\n", fn.c_str());
+        fprintf(stderr, "  Fix: ensure there are numeric data rows after the 2-line header.\n");
+        myexit(ERRFileIO);
+    }
+
+    minTime = localMin;
+    maxTime = localMax;
+    timeRangeCached = 1;
+}
+
+double _TimeSeriesData::getMinTime() const
+{
+    computeTimeRange();
+    return minTime;
+}
+
+double _TimeSeriesData::getMaxTime() const
+{
+    computeTimeRange();
+    return maxTime;
+}
+
 void _TimeSeriesData::read_csv()
 {
     if (!eof) {
+        computeTimeRange(); // validates monotonic time column and caches min/max time
         std::ifstream file(fn);
         CheckFile(&file, fn.c_str());
         std::string str;
@@ -58,18 +164,56 @@ void _TimeSeriesData::read_csv()
             /* Line 1= size of table; Line 2= Head of table */
             getline(file, str);
         }
-        for (int i = 0; i < MAXQUE && getline(file, str); i++) {
-            //std::cout << str << endl;
-            std::istringstream iss(str);
-            Length++;
-            for (int j = 0; j < ncol; j++) {
-                iss >> ts[i][j];
-                if (j == 0) {
-                    ts[i][j] *= 1440.;    /* Day to minute */
-                }
-                //cout << ts[i][j] << "\t";
+        long lineNo = (long)(MAXQUE * nQue + 2); // 1-based line number of last skipped line
+        bool hasPrev = false;
+        double prevTimeMin = 0.0;
+        long prevLineNo = 0;
+        for (int i = 0; i < MAXQUE && getline(file, str); ) {
+            lineNo++;
+
+            const size_t first = str.find_first_not_of(" \t\r\n");
+            if (first == std::string::npos || str[first] == '#') {
+                continue;
             }
-            //cout << endl;
+
+            std::istringstream iss(str);
+            double timeDay = 0.0;
+            if (!(iss >> timeDay)) {
+                fprintf(stderr, "\n  Fatal Error: Failed to parse time value.\n");
+                fprintf(stderr, "  File: %s\n", fn.c_str());
+                fprintf(stderr, "  Line: %ld\n", lineNo);
+                fprintf(stderr, "  Content: %s\n", str.c_str());
+                myexit(ERRDATAIN);
+            }
+            const double timeMin = timeDay * 1440.0; // Day -> minute
+
+            if (hasPrev && timeMin + 1e-12 < prevTimeMin) {
+                fprintf(stderr, "\n  Fatal Error: Time column is not monotonic non-decreasing.\n");
+                fprintf(stderr, "  File: %s\n", fn.c_str());
+                fprintf(stderr, "  Previous line: %ld, time = %.15g day (%.3f min)\n",
+                        prevLineNo, prevTimeMin / 1440.0, prevTimeMin);
+                fprintf(stderr, "  Current  line: %ld, time = %.15g day (%.3f min)\n",
+                        lineNo, timeMin / 1440.0, timeMin);
+                fprintf(stderr, "  Fix: sort the time column ascending (allow equal), or regenerate the file.\n");
+                myexit(ERRDATAIN);
+            }
+
+            ts[i][0] = timeMin;
+            for (int j = 1; j < ncol; j++) {
+                if (!(iss >> ts[i][j])) {
+                    fprintf(stderr, "\n  Fatal Error: Failed to parse numeric column %d.\n", j + 1);
+                    fprintf(stderr, "  File: %s\n", fn.c_str());
+                    fprintf(stderr, "  Line: %ld\n", lineNo);
+                    fprintf(stderr, "  Content: %s\n", str.c_str());
+                    myexit(ERRDATAIN);
+                }
+            }
+
+            hasPrev = true;
+            prevTimeMin = timeMin;
+            prevLineNo = lineNo;
+            Length++;
+            i++;
         }
         nQue++;            /* Number of the Queue was reload */
         if (!file.eof()) {

--- a/src/classes/TimeSeriesData.hpp
+++ b/src/classes/TimeSeriesData.hpp
@@ -29,9 +29,14 @@ public:
     void    checkValue(int icol, double xmin, double xmax, const char *varname);
     int     get_Ncol();
     long    getStartTime() const;
+    double  getMinTime() const;
+    double  getMaxTime() const;
     double  xyz[3]={NA_VALUE, NA_VALUE, NA_VALUE};
 private:
     long StartTime;
+    mutable int timeRangeCached = 0;
+    mutable double minTime = NA_VALUE;
+    mutable double maxTime = NA_VALUE;
     int ncol = 0;
     int Length;
     int eof;
@@ -42,8 +47,8 @@ private:
     
     //    void    buildfn(std::string fforc);
     double  interpolation(double t);
+    void    computeTimeRange() const;
 };
 
 void CheckFile(std::ifstream * fp, const char *s);
 #endif                /* TimeSeriesData_hpp */
-


### PR DESCRIPTION
## Summary
Implements #3 [A3] 时间列单调性与覆盖范围预检查（fail-fast）

## Changes
- Add `getMinTime()` / `getMaxTime()` methods to `_TimeSeriesData`
- Implement `computeTimeRange()` with lazy caching for time bounds calculation
- Add monotonicity validation (non-decreasing) in both `computeTimeRange()` and `read_csv()`
- Add forcing coverage pre-check in `validateTimeStamps()` before simulation starts
- Fail-fast error reporting with:
  - File name, line numbers, and actual time values for non-monotonic data
  - Simulation period vs forcing coverage comparison for coverage issues

## Files Changed
- `src/classes/TimeSeriesData.hpp` - Add new methods and caching members
- `src/classes/TimeSeriesData.cpp` - Implement time range computation and validation
- `src/ModelData/MD_readin.cpp` - Add coverage pre-check in validateTimeStamps()

## Testing
- [x] `make shud` compiles successfully
- [x] `./shud ccw` runs without errors
- [x] Numerical results unchanged

## Acceptance Criteria
- [x] Coverage insufficient → fail-fast before integration starts
- [x] Non-monotonic time → reports file, line numbers, adjacent time values
- [x] ccw sample: passes check, no change to numerical results

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)