### PR TITLE
feat(A4): implement unified TSD pointer update mechanism

### DIFF
--- a/src/Model/shud.cpp
+++ b/src/Model/shud.cpp
@@ -89,6 +89,7 @@ double SHUD(FileIn *fin, FileOut *fout){
         /* inner loops to next output points with ET step size control */
         tnext += MD->CS.SolverStep;
         while (t < tnext) {
+            MD->updateAllTimeSeries(t);
             MD->updateforcing(t);
             /* calculate Interception Storage */
             MD->ET(t, tnext);
@@ -206,6 +207,7 @@ double SHUD_uncouple(FileIn *fin, FileOut *fout){
 //                tout = t + MD->CS.ETStep;
 //            }
             dt = tout - t;
+            MD->updateAllTimeSeries(t);
             MD->updateforcing(t);
 //            if(t >= tnext_et){
                 /* calculate Interception Storage */
@@ -301,4 +303,3 @@ int SHUD(int argc, char *argv[]){
     delete fout;
     return 0;
 }
-

--- a/src/ModelData/MD_ET.cpp
+++ b/src/ModelData/MD_ET.cpp
@@ -9,15 +9,6 @@
 #include "Model_Data.hpp"
 void Model_Data::updateforcing(double t){
     int i;
-#ifdef _OPENMP_ON
-#pragma omp for
-#endif
-    for (i = 0; i < NumForc; i++){
-        tsd_weather[i].movePointer(t);
-    }
-    tsd_MF.movePointer(t);
-    tsd_LAI.movePointer(t);
-//    tsd_RL.movePointer(t);
     for(i = 0; i < NumEle; i++){
         Ele[i].updateElement(uYsf[i], uYus[i], uYgw[i]);
         tReadForcing(t,i);
@@ -226,4 +217,3 @@ void Model_Data::f_etFlux(int i, double t){
 #ifdef DEBUG
 #endif
 }
-

--- a/src/ModelData/MD_update.cpp
+++ b/src/ModelData/MD_update.cpp
@@ -1,5 +1,44 @@
 #include "Model_Data.hpp"
 
+void Model_Data::updateAllTimeSeries(double t_min)
+{
+    if (NumForc > 0 && tsd_weather != nullptr) {
+        for (int i = 0; i < NumForc; i++) {
+            tsd_weather[i].movePointer(t_min);
+        }
+    }
+
+    if (NumLC > 0) {
+        tsd_LAI.movePointer(t_min);
+    }
+    if (NumMeltF > 0) {
+        tsd_MF.movePointer(t_min);
+    }
+
+    if (ieSS && NumSSEle > 0) {
+        tsd_eleSS.movePointer(t_min);
+    }
+
+    if (ieBC1 && NumBCEle1 > 0) {
+        tsd_eyBC.movePointer(t_min);
+    }
+    if (ieBC2 && NumBCEle2 > 0) {
+        tsd_eqBC.movePointer(t_min);
+    }
+    if (irBC1 && NumBCRiv1 > 0) {
+        tsd_ryBC.movePointer(t_min);
+    }
+    if (irBC2 && NumBCRiv2 > 0) {
+        tsd_rqBC.movePointer(t_min);
+    }
+    if (ilBC1 && NumBCLake1 > 0) {
+        tsd_lyBC.movePointer(t_min);
+    }
+    if (ilBC2 && NumBCLake2 > 0) {
+        tsd_lqBC.movePointer(t_min);
+    }
+}
+
 void Model_Data::f_updatei(double  *Y, double *DY, double t, int flag){
     switch (flag) {
         case 1:

--- a/src/ModelData/Model_Data.hpp
+++ b/src/ModelData/Model_Data.hpp
@@ -253,6 +253,7 @@ public:
     void debugData(const char *fn);
     void f_etFlux(int i, double t);
     void ET(double t, double tnext);
+    void updateAllTimeSeries(double t_min);
     void updateforcing(double t);
     double getArea();
     void PassValue();


### PR DESCRIPTION
## Summary
Implements #4 [A4] 统一推进所有会被使用的 TSD 指针（避免冻结）

## Changes
- Add `Model_Data::updateAllTimeSeries(double t_min)` method
- Centralize pointer advancement for all active TSDs
- Call at start of each MTS before CVODE integration
- Remove redundant `movePointer()` calls from `updateforcing()`

## Files Changed
- `src/ModelData/Model_Data.hpp` - Add method declaration
- `src/ModelData/MD_update.cpp` - Implement updateAllTimeSeries
- `src/Model/shud.cpp` - Call in main time-stepping loop
- `src/ModelData/MD_ET.cpp` - Remove redundant movePointer calls

## Testing
- [x] `make shud` compiles successfully
- [x] `./shud ccw` runs without errors

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)