### PR TITLE
feat(B2): add solar geometry and TSR factor calculation module

### DIFF
--- a/src/Equations/SolarRadiation.cpp
+++ b/src/Equations/SolarRadiation.cpp
@@ -188,7 +188,10 @@ double terrainFactor(double nx, double ny, double nz, const SolarPosition& sp, d
         return 0.0;
     }
 
-    if (!isFinite(cap) || cap < 0.0) {
+    if (!isFinite(cap)) {
+        // Treat missing/invalid cap as "effectively uncapped" while still keeping a finite bound.
+        cap = 10.0;
+    } else if (cap < 0.0) {
         cap = 0.0;
     }
     if (!isFinite(cosz_min) || cosz_min < 0.0) {

--- a/src/Equations/SolarRadiation.hpp
+++ b/src/Equations/SolarRadiation.hpp
@@ -14,11 +14,26 @@ struct SolarPosition {
     double hourAngle;   /* hour angle [rad], 0 at solar noon, positive afternoon */
 };
 
+/*
+ * Compute solar position at simulation time.
+ *
+ * t_min is simulation time in minutes (not local clock time).
+ *
+ * Note: this overload estimates timezone from longitude using round(lon_deg / 15).
+ * This geometric estimate can be ~1 hour off in political timezones.
+ */
 SolarPosition solarPosition(double t_min,
                             double lat_deg,
                             double lon_deg,
                             const TimeContext& tc);
 
+/*
+ * Compute solar position at simulation time.
+ *
+ * t_min is simulation time in minutes (not local clock time).
+ *
+ * timezone_hours is the UTC offset in hours (e.g., UTC+8 = 8.0).
+ */
 SolarPosition solarPosition(double t_min,
                             double lat_deg,
                             double lon_deg,
@@ -33,4 +48,3 @@ double terrainFactor(double nx,
                      double cosz_min);
 
 #endif /* SolarRadiation_hpp */
-


### PR DESCRIPTION
## Summary

Implements Issue #9: Add independent solar geometry and TSR factor calculation module.

## Changes

- **New files**:
  - `src/Equations/SolarRadiation.hpp` - API definitions
  - `src/Equations/SolarRadiation.cpp` - Implementation

- **API**:
  - `struct SolarPosition` - Solar position data (cosZ, zenith, azimuth, declination, hourAngle)
  - `solarPosition()` - Calculate solar position using NOAA algorithm
  - `terrainFactor()` - Calculate TSR correction factor with boundary conditions

- **Boundary conditions** (v1 hardcoded):
  - Night: `cosZ <= 0` → `factor = 0`
  - Back-facing: `cosI <= 0` → `factor = 0`
  - Cap: `factor = min(factor, cap)`
  - Near-horizon protection: `cosz_min` prevents division by small values

- **Conventions**:
  - Azimuth: North=0, East=π/2 (consistent with Issue #8 aspect)
  - Default timezone: estimated from longitude (`round(lon/15)`)

## Testing

- ✅ Compiles successfully with `make shud`
- ✅ All calculations include NaN/Inf guards
- ✅ Horizontal plane: factor ≈ 1 (daytime), factor = 0 (night)

## Related Issues

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)