### PR TITLE
fix(X1): correct Lake CVODE state vector from u2 to u5

### DIFF
--- a/src/Model/shud.cpp
+++ b/src/Model/shud.cpp
@@ -271,7 +271,7 @@ double SHUD_uncouple(FileIn *fin, FileOut *fout){
                     flag = CVodeSetStopTime(mem5, tout);
                     check_flag(&flag, "CVodeSetStopTime", 1);
                 }
-                flag = CVode(mem5, tout, u2, &t, CV_NORMAL);
+                flag = CVode(mem5, tout, u5, &t, CV_NORMAL);
                 check_flag(&flag, "CVode5 LAKE", 1);
             }
         }


### PR DESCRIPTION
## Summary

Fixes critical bug in Lake module CVODE call where wrong state vector was used.

## Problem

In `src/Model/shud.cpp:274`, Lake module's CVode call incorrectly used `u2` (UNSAT state vector) instead of `u5` (LAKE state vector):

```c
flag = CVode(mem5, tout, u2, &t, CV_NORMAL);  // ❌ Wrong
```

But `mem5` is initialized with `u5` at line 190:
```c
SetCVODE(mem5, f_lake, MD, u5, LS5, sunctx5);
```

## Fix

Changed line 274 to use correct state vector:
```c
flag = CVode(mem5, tout, u5, &t, CV_NORMAL);  // ✅ Correct
```

## Verification

- ✅ Full codebase scan: no other mem/state vector mismatches found
- ✅ Compilation: `make shud` passes
- ✅ Lake functionality: `./shud qhh` runs successfully

## Impact

This bug could cause:
- Numerical errors in lake-enabled cases
- Silent data corruption
- Unstable results

## Testing

Tested with qhh case (lake-enabled), model runs to completion without errors.

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)