### PR TITLE
feat(C1): add TSR validation scripts and framework

### DIFF
--- a/.claude/specs/issue-13-tsr-validation-scripts/dev-plan.md
+++ b/.claude/specs/issue-13-tsr-validation-scripts/dev-plan.md
@@ -1,0 +1,74 @@
+# TSR Validation Scripts - Development Plan
+
+## Overview
+创建自动化验证脚本，对比 TSR 开关前后的模型输出，确保 TSR 特性可复现且输出隔离。
+
+## Task Breakdown
+
+### Task 1: 搭建验证目录结构
+- **ID**: task-1
+- **type**: quick-fix
+- **Description**: 创建 validation/tsr/ 目录结构，配置 .gitignore（排除 tmp/ 和 output/），编写 README.md 说明脚本用途和使用方法
+- **File Scope**: validation/tsr/README.md, validation/tsr/.gitignore
+- **Dependencies**: None
+- **Test Command**: `test -d validation/tsr && test -f validation/tsr/README.md && test -f validation/tsr/.gitignore && echo "Directory structure validated"`
+- **Test Focus**:
+  - 验证目录创建成功
+  - README.md 包含脚本使用说明
+  - .gitignore 正确排除 tmp/ 和 output/ 目录
+
+### Task 2: 实现 TSR 基准和对比运行脚本
+- **ID**: task-2
+- **type**: default
+- **Description**: 实现三个脚本：
+  - `_common.sh`：公共函数（错误检查、输入隔离复制、配置修改、输出备份）
+  - `run_baseline.sh`：TSR=OFF，输出到 output/ccw.base/
+  - `run_tsr.sh`：TSR=ON，输出到 output/ccw.tsr/
+  每个脚本需包含：二进制存在性检查、输入目录检查、工作目录设置、cfg.para 的 TERRAIN_RADIATION 配置 upsert、已有输出目录自动备份
+- **File Scope**: validation/tsr/_common.sh, validation/tsr/run_baseline.sh, validation/tsr/run_tsr.sh
+- **Dependencies**: Depends on task-1
+- **Test Command**: `bash validation/tsr/run_baseline.sh && test -d validation/tsr/output/ccw.base && bash validation/tsr/run_tsr.sh && test -d validation/tsr/output/ccw.tsr && echo "Scripts executed successfully"`
+- **Test Focus**:
+  - 缺少二进制文件时报错退出
+  - 缺少输入目录时报错退出
+  - 成功复制输入到 validation/tsr/tmp/
+  - cfg.para 中 TERRAIN_RADIATION 正确设置为 0（baseline）或 1（tsr）
+  - 输出目录已存在时自动备份为 .bak{timestamp}
+  - 两次运行输出到不同目录且互不覆盖
+
+### Task 3: 实现集成测试脚本
+- **ID**: task-3
+- **type**: default
+- **Description**: 实现 integration_test.sh，执行以下深度验证：
+  - 调用 run_baseline.sh 和 run_tsr.sh
+  - 检查两个输出目录存在且非空
+  - 解析关键 .dat 文件（如 ccw.surf、ccw.rad）的 header（行数、列数、时间步）
+  - 采样验证数值范围合理性（非 NaN、非全零）
+  - 对比两组输出的差异（TSR=ON 时辐射应有差异）
+  - 生成验证报告到 validation/tsr/test_report.txt
+- **File Scope**: validation/tsr/integration_test.sh
+- **Dependencies**: Depends on task-2
+- **Test Command**: `bash validation/tsr/integration_test.sh && grep -q "PASS" validation/tsr/test_report.txt && echo "Integration test passed"`
+- **Test Focus**:
+  - 两个脚本顺利执行无错误
+  - 输出文件存在且文件大小 > 0
+  - .dat 文件 header 解析正确（行数、列数、时间步匹配预期）
+  - 数值采样验证通过（无 NaN、非全零、范围合理）
+  - TSR=ON 与 TSR=OFF 的辐射输出存在数值差异
+  - 测试报告清晰标注 PASS/FAIL 和失败原因
+
+## Acceptance Criteria
+- [ ] 用户执行一条命令可复现 TSR 开关对比实验
+- [ ] TSR=OFF 输出到 output/ccw.base/，TSR=ON 输出到 output/ccw.tsr/，互不覆盖
+- [ ] 脚本在以下场景给出清晰错误信息：缺少二进制、缺少输入目录、缺少工作目录权限
+- [ ] 集成测试深度验证输出文件内容（header 解析、数值采样、差异对比）
+- [ ] 所有脚本通过集成测试且测试报告显示 PASS
+- [ ] README.md 提供完整的使用说明和故障排查指南
+
+## Technical Notes
+- **输入隔离策略**：每次运行前复制 input/ccw/ 到 validation/tsr/tmp/ccw，避免污染原始输入
+- **配置修改策略**：使用 sed/awk upsert cfg.para 中的 TERRAIN_RADIATION 行，保留其他配置不变
+- **输出备份策略**：检测到已有输出目录时，重命名为 `.bak$(date +%Y%m%d_%H%M%S)` 后再运行
+- **深度验证策略**：不仅检查文件存在，还需解析文件 header（行数、列数、时间步）和采样验证数值范围，确保输出有效性
+- **错误处理原则**：所有错误场景必须打印可操作的错误信息（如"缺少二进制，请运行 make 编译"），并使用非零退出码
+- **可移植性**：脚本应使用 POSIX 兼容的 shell 语法，避免依赖 bash 特定特性（除非明确声明 #!/bin/bash）

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,9 @@ forcing
 rAnalysis/test.R
 *.*.swp
 *.DS_Store
+
+# Validation harness artifacts
+validation/tsr/tmp/
+
+# Allow committing validation scripts (this repo ignores *.sh by default)
+!validation/**/*.sh

--- a/validation/tsr/.gitignore
+++ b/validation/tsr/.gitignore
@@ -1,0 +1,2 @@
+tmp/
+output/

--- a/validation/tsr/README.md
+++ b/validation/tsr/README.md
@@ -1,0 +1,68 @@
+# TSR validation (baseline vs TSR=ON)
+
+此目录用于验证 Terrain Solar Radiation (TSR) 开关对 `ccw` 示例流域输出的影响，保证：
+- **不修改** `input/ccw` 原文件（在 `validation/tsr/tmp/` 生成工作副本并在副本上改配置）
+- 两组输出互不覆盖：`output/ccw.base/` vs `output/ccw.tsr/`
+
+## 目录结构
+
+- `validation/tsr/run_baseline.sh`：TSR=OFF（`TERRAIN_RADIATION=0`）
+- `validation/tsr/run_tsr.sh`：TSR=ON（`TERRAIN_RADIATION=1`）
+- `validation/tsr/integration_test.sh`：端到端运行 + 深度校验（读取二进制 `.dat` 输出并检查数值关系）
+- `validation/tsr/tmp/`：运行时创建的输入工作副本（已加入 `validation/tsr/.gitignore`）
+
+## 前置条件
+
+- 已编译二进制：仓库根目录存在可执行文件 `./shud`
+  - 如果没有：`make shud`
+- `python3`（用于 `integration_test.sh` 深度校验）
+
+## 使用方法
+
+从仓库根目录执行：
+
+```bash
+bash validation/tsr/run_baseline.sh
+bash validation/tsr/run_tsr.sh
+```
+
+运行端到端集成验证：
+
+```bash
+bash validation/tsr/integration_test.sh
+```
+
+## 可调参数（环境变量）
+
+默认为了验证速度，会在输入工作副本中写入/覆盖以下参数：
+- `END`（默认 `2` 天）
+- `DT_QE_ET`（默认 `60` 分钟；`rn_h/rn_t/rn_factor` 输出频率绑定在 `DT_QE_ET`）
+- `TERRAIN_RADIATION`（baseline=0 / tsr=1）
+
+可通过环境变量覆盖默认值：
+
+```bash
+SHUD_VALIDATION_END_DAYS=2 SHUD_VALIDATION_DT_QE_ET_MIN=60 bash validation/tsr/run_tsr.sh
+```
+
+## 输出位置
+
+- Baseline：`output/ccw.base/`
+- TSR ON：`output/ccw.tsr/`
+
+重复运行说明：
+- 若目标输出目录已存在且非空，脚本会自动将其移动为 `*.bak.YYYYmmdd-HHMMSS`，再生成新的输出目录
+- 模型标准输出/错误输出写入对应目录的 `run.log`
+
+关键 TSR 输出文件（两组目录都会生成）：
+- `ccw.rn_h.dat`：水平面太阳辐射（W/m²）
+- `ccw.rn_t.dat`：地形修正后辐射（W/m²）
+- `ccw.rn_factor.dat`：地形因子（无量纲）
+
+## 故障排查
+
+- 提示 `required file missing: .../shud`：先在仓库根目录编译 `make shud`，并确认 `./shud` 可执行。
+- 提示 `required directory missing: .../input/ccw`：确认示例输入目录存在且完整（应包含 `ccw.cfg.para`、`ccw.tsd.forc` 等文件）。
+- 提示 `directory not writable` 或无法创建目录：检查 `output/` 和 `validation/tsr/tmp/` 是否有写权限；必要时清理旧目录或修复权限。
+- `integration_test.sh` 报 `.dat` 解析/截断：优先查看对应输出目录下的 `run.log`，通常是模型中途退出导致文件不完整。
+- `integration_test.sh` 报 “baseline vs tsr ... identical”：查看 `output/ccw.tsr/run.log` 确认 `TERRAIN_RADIATION=1` 生效；确认运行的是最新编译的 `./shud`。

--- a/validation/tsr/_common.sh
+++ b/validation/tsr/_common.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+die() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+info() {
+  echo "==> $*" >&2
+}
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || die "missing required command: $1"
+}
+
+script_dir() {
+  cd "$(dirname "${BASH_SOURCE[0]}")" && pwd
+}
+
+repo_root() {
+  local sd
+  sd="$(script_dir)"
+  cd "${sd}/../.." && pwd
+}
+
+ensure_executable_file() {
+  local path="$1"
+  [[ -f "$path" ]] || die "required file missing: $path"
+  [[ -x "$path" ]] || die "required file is not executable: $path"
+}
+
+ensure_dir_exists() {
+  local path="$1"
+  [[ -d "$path" ]] || die "required directory missing: $path"
+}
+
+ensure_dir_writable() {
+  local path="$1"
+  mkdir -p "$path" || die "failed to create directory: $path"
+  local probe="${path}/.writetest.$$"
+  : >"$probe" 2>/dev/null || die "directory not writable: $path"
+  rm -f "$probe"
+}
+
+backup_dir_if_exists() {
+  local path="$1"
+  if [[ -d "$path" ]]; then
+    if find "$path" -mindepth 1 -maxdepth 1 -print -quit | grep -q .; then
+      local ts
+      ts="$(date +"%Y%m%d-%H%M%S")"
+      local backup="${path}.bak.${ts}"
+      info "output dir exists; moving to ${backup}"
+      mv "$path" "$backup"
+    else
+      rmdir "$path" 2>/dev/null || true
+    fi
+  fi
+}
+
+copy_tree() {
+  local src="$1"
+  local dst="$2"
+  ensure_dir_exists "$src"
+  rm -rf "$dst"
+  mkdir -p "$dst"
+  if command -v rsync >/dev/null 2>&1; then
+    rsync -a "${src}/" "${dst}/"
+  else
+    cp -R "${src}/." "${dst}/"
+  fi
+}
+
+upsert_cfg_kv() {
+  local file="$1"
+  local key="$2"
+  local value="$3"
+  local tmp
+  tmp="$(mktemp)"
+  awk -v key="$key" -v value="$value" '
+    BEGIN{found=0}
+    /^[[:space:]]*#/ {print; next}
+    /^[[:space:]]*$/ {print; next}
+    {
+      k=$1
+      if (toupper(k)==toupper(key)) {
+        print key "\t" value
+        found=1
+      } else {
+        print
+      }
+      next
+    }
+    END{
+      if(found==0){
+        print key "\t" value
+      }
+    }
+  ' "$file" >"$tmp"
+  mv "$tmp" "$file"
+}
+
+set_forcing_csv_basepath() {
+  local forc_list="$1"
+  local new_path="$2"
+  [[ -f "$forc_list" ]] || die "missing forcing list file: $forc_list"
+  local tmp
+  tmp="$(mktemp)"
+  awk -v new_path="$new_path" 'NR==2{print new_path; next} {print}' "$forc_list" >"$tmp"
+  mv "$tmp" "$forc_list"
+}
+
+write_ccw_project_file() {
+  local project_file="$1"
+  local in_rel="$2"
+  local out_rel="$3"
+  cat >"$project_file" <<EOF
+PRJ	 ccw
+INPATH	 ${in_rel}
+OUTPATH	 ${out_rel}
+MESH	 ${in_rel}/ccw.sp.mesh
+ATT	 ${in_rel}/ccw.sp.att
+RIV	 ${in_rel}/ccw.sp.riv
+RIVSEG	 ${in_rel}/ccw.sp.rivseg
+CALIB	 ${in_rel}/ccw.cfg.calib
+PARA	 ${in_rel}/ccw.cfg.para
+INIT	 ${in_rel}/ccw.cfg.ic
+LC	 ${in_rel}/ccw.para.lc
+SOIL	 ${in_rel}/ccw.para.soil
+GEOL	 ${in_rel}/ccw.para.geol
+FORC	 ${in_rel}/ccw.tsd.forc
+LAI	 ${in_rel}/ccw.tsd.lai
+MF	 ${in_rel}/ccw.tsd.mf
+RL	 ${in_rel}/ccw.tsd.rl
+EOF
+}
+
+run_ccw_case() {
+  local tsr_flag="$1"          # 0/1
+  local out_rel="$2"           # e.g. output/ccw.base
+  local tmp_rel="$3"           # e.g. validation/tsr/tmp/ccw.base
+  local label="$4"             # e.g. baseline/tsr
+
+  local root
+  root="$(repo_root)"
+
+  local shud_bin="${root}/shud"
+  ensure_executable_file "$shud_bin"
+
+  local input_src="${root}/input/ccw"
+  ensure_dir_exists "$input_src"
+
+  local out_dir="${root}/${out_rel}"
+  ensure_dir_writable "${root}/output"
+  backup_dir_if_exists "$out_dir"
+  ensure_dir_writable "$out_dir"
+
+  local tmp_dir="${root}/${tmp_rel}"
+  mkdir -p "${root}/validation/tsr/tmp"
+  copy_tree "$input_src" "$tmp_dir"
+
+  local cfg="${tmp_dir}/ccw.cfg.para"
+  local forc="${tmp_dir}/ccw.tsd.forc"
+  [[ -f "$cfg" ]] || die "missing cfg.para in tmp copy: $cfg"
+  [[ -f "$forc" ]] || die "missing tsd.forc in tmp copy: $forc"
+
+  local end_days="${SHUD_VALIDATION_END_DAYS:-2}"
+  local dt_qe_et_min="${SHUD_VALIDATION_DT_QE_ET_MIN:-60}"
+  upsert_cfg_kv "$cfg" "END" "${end_days}"
+  upsert_cfg_kv "$cfg" "DT_QE_ET" "${dt_qe_et_min}"
+  upsert_cfg_kv "$cfg" "TERRAIN_RADIATION" "${tsr_flag}"
+
+  set_forcing_csv_basepath "$forc" "./${tmp_rel}"
+
+  local project_file="${tmp_dir}/ccw.SHUD"
+  write_ccw_project_file "$project_file" "./${tmp_rel}" "./${out_rel}"
+
+  info "running ${label}: TSR=${tsr_flag}, END=${end_days} day(s), DT_QE_ET=${dt_qe_et_min} min"
+  (
+    cd "$root"
+    "${shud_bin}" -p "${project_file}" >"${out_dir}/run.log" 2>&1
+  )
+
+  for f in "ccw.rn_h.dat" "ccw.rn_t.dat" "ccw.rn_factor.dat"; do
+    [[ -f "${out_dir}/${f}" ]] || die "missing expected output file: ${out_dir}/${f}"
+  done
+
+  info "done: ${label} -> ${out_rel}"
+}

--- a/validation/tsr/integration_test.sh
+++ b/validation/tsr/integration_test.sh
@@ -1,0 +1,360 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+sd="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${sd}/_common.sh"
+
+need_cmd python3
+
+root="$(cd "${sd}/../.." && pwd)"
+report_path="${sd}/test_report.txt"
+
+{
+  echo "TSR Integration Test Report"
+  echo "Timestamp: $(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+  echo "Repo root: ${root}"
+  echo
+} >"${report_path}"
+
+if ! baseline_out="$(bash "${sd}/run_baseline.sh" 2>&1)"; then
+  {
+    echo "Step: run_baseline.sh: FAIL"
+    echo "${baseline_out}"
+    echo
+    echo "RESULT: FAIL"
+  } >>"${report_path}"
+  echo "${baseline_out}" >&2
+  exit 1
+fi
+{
+  echo "Step: run_baseline.sh: OK"
+  echo
+} >>"${report_path}"
+
+if ! tsr_out="$(bash "${sd}/run_tsr.sh" 2>&1)"; then
+  {
+    echo "Step: run_tsr.sh: FAIL"
+    echo "${tsr_out}"
+    echo
+    echo "RESULT: FAIL"
+  } >>"${report_path}"
+  echo "${tsr_out}" >&2
+  exit 1
+fi
+{
+  echo "Step: run_tsr.sh: OK"
+  echo
+} >>"${report_path}"
+
+SHUD_REPO_ROOT="${root}" SHUD_REPORT_PATH="${report_path}" python3 - <<'PY'
+from __future__ import annotations
+
+import math
+import os
+import struct
+from pathlib import Path
+from dataclasses import dataclass
+import traceback
+
+
+@dataclass
+class DatMeta:
+    path: Path
+    header_text: str
+    start_time: float
+    num_var: int
+    num_records: int
+    dt_min: float
+    data_offset: int
+    record_size: int
+
+
+class ValidationError(RuntimeError):
+    pass
+
+
+def report_append(report_path: Path, lines: list[str]) -> None:
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    with report_path.open("a", encoding="utf-8") as f:
+        for line in lines:
+            f.write(f"{line}\n")
+
+
+def header_lines(text: str) -> list[str]:
+    cleaned = text.replace("\x00", "").strip()
+    if not cleaned:
+        return []
+    return [ln.rstrip() for ln in cleaned.splitlines() if ln.strip()]
+
+
+def read_meta(path: Path) -> DatMeta:
+    if not path.exists():
+        raise ValidationError(f"missing .dat file: {path}")
+    size = path.stat().st_size
+    if size <= 0:
+        raise ValidationError(f"empty .dat file: {path}")
+
+    with path.open("rb") as f:
+        header_raw = f.read(1024)
+        if len(header_raw) != 1024:
+            raise ValidationError(f"short header (<1024B) in {path}")
+        header_text = header_raw.decode("utf-8", errors="ignore")
+
+        start_time_raw = f.read(8)
+        num_var_raw = f.read(8)
+        if len(start_time_raw) != 8 or len(num_var_raw) != 8:
+            raise ValidationError(f"truncated metadata in {path}")
+        start_time = struct.unpack("d", start_time_raw)[0]
+        num_var = int(struct.unpack("d", num_var_raw)[0])
+        if num_var <= 0:
+            raise ValidationError(f"invalid num_var={num_var} in {path}")
+
+    data_offset = 1024 + 16 + 8 * num_var
+    record_size = 8 * (1 + num_var)
+    if size < data_offset:
+        raise ValidationError(f"file too small for header+cols in {path} (size={size}, need>={data_offset})")
+    rem = size - data_offset
+    if rem % record_size != 0:
+        raise ValidationError(f"data section not aligned in {path} (rem={rem}, rec_size={record_size})")
+    num_records = rem // record_size
+    if num_records <= 0:
+        raise ValidationError(f"no records in {path}")
+
+    # Derive dt from first two time stamps (minutes) if possible.
+    dt_min = 0.0
+    if num_records >= 2:
+        with path.open("rb") as f:
+            f.seek(data_offset, os.SEEK_SET)
+            first = f.read(record_size)
+            second = f.read(record_size)
+            if len(first) != record_size or len(second) != record_size:
+                raise ValidationError(f"truncated records in {path}")
+            t0 = struct.unpack_from("d", first, 0)[0]
+            t1 = struct.unpack_from("d", second, 0)[0]
+            dt_min = t1 - t0
+    else:
+        dt_min = 0.0
+
+    return DatMeta(
+        path=path,
+        header_text=header_text,
+        start_time=start_time,
+        num_var=num_var,
+        num_records=num_records,
+        dt_min=dt_min,
+        data_offset=data_offset,
+        record_size=record_size,
+    )
+
+
+def iter_records(meta: DatMeta):
+    with meta.path.open("rb") as f:
+        f.seek(meta.data_offset, os.SEEK_SET)
+        for _ in range(meta.num_records):
+            chunk = f.read(meta.record_size)
+            if len(chunk) != meta.record_size:
+                raise ValidationError(f"truncated record in {meta.path}")
+            t = struct.unpack_from("d", chunk, 0)[0]
+            values = struct.unpack_from(f"{meta.num_var}d", chunk, 8)
+            yield t, values
+
+
+def scan_stats(meta: DatMeta, abs_cap: float = 1e7) -> dict[str, float]:
+    mn = math.inf
+    mx = -math.inf
+    non_finite = 0
+    non_zero = 0
+    total = 0
+    eps = 1e-12
+    for _, values in iter_records(meta):
+        for x in values:
+            total += 1
+            if not math.isfinite(x):
+                non_finite += 1
+                continue
+            if abs(x) > abs_cap:
+                raise ValidationError(f"value magnitude too large in {meta.path} (|x|>{abs_cap:g})")
+            if abs(x) > eps:
+                non_zero += 1
+            if x < mn:
+                mn = x
+            if x > mx:
+                mx = x
+    if total == 0:
+        raise ValidationError(f"no numeric payload in {meta.path}")
+    if non_finite != 0:
+        raise ValidationError(f"non-finite values detected in {meta.path} (count={non_finite})")
+    if non_zero == 0:
+        raise ValidationError(f"all-zero payload detected in {meta.path}")
+    return {"min": mn, "max": mx, "total": float(total)}
+
+
+def max_abs_from_constant(meta: DatMeta, c: float) -> float:
+    m = 0.0
+    for _, values in iter_records(meta):
+        for x in values:
+            d = abs(x - c)
+            if d > m:
+                m = d
+    return m
+
+
+def max_abs_diff(a: DatMeta, b: DatMeta) -> float:
+    if a.num_var != b.num_var or a.num_records != b.num_records:
+        raise ValidationError("shape mismatch for diff")
+    m = 0.0
+    for (_, va), (_, vb) in zip(iter_records(a), iter_records(b)):
+        for xa, xb in zip(va, vb):
+            d = abs(xa - xb)
+            if d > m:
+                m = d
+    return m
+
+
+def max_abs_err_relation(rn_h: DatMeta, rn_t: DatMeta, factor: DatMeta) -> float:
+    if rn_h.num_var != rn_t.num_var or rn_h.num_var != factor.num_var:
+        raise ValidationError("num_var mismatch in relation")
+    if rn_h.num_records != rn_t.num_records or rn_h.num_records != factor.num_records:
+        raise ValidationError("record count mismatch in relation")
+
+    m = 0.0
+    for (th, vh), (tt, vt), (tf, vf) in zip(iter_records(rn_h), iter_records(rn_t), iter_records(factor)):
+        if not (th == tt == tf):
+            raise ValidationError("time index mismatch across rn_h/rn_t/factor")
+        for h, t, f in zip(vh, vt, vf):
+            d = abs(t - (h * f))
+            if d > m:
+                m = d
+    return m
+
+
+root = Path(os.environ.get("SHUD_REPO_ROOT", os.getcwd()))
+report_path = Path(os.environ.get("SHUD_REPORT_PATH", root / "validation" / "tsr" / "test_report.txt"))
+expected_end_days = int(os.environ.get("SHUD_VALIDATION_END_DAYS", "2"))
+expected_dt_min = float(os.environ.get("SHUD_VALIDATION_DT_QE_ET_MIN", "60"))
+
+base_dir = root / "output" / "ccw.base"
+tsr_dir = root / "output" / "ccw.tsr"
+
+
+def ensure_dir_nonempty(path: Path) -> None:
+    if not path.is_dir():
+        raise ValidationError(f"missing output directory: {path}")
+    if not any(path.iterdir()):
+        raise ValidationError(f"output directory is empty: {path}")
+
+
+def case_metas(out_dir: Path) -> tuple[DatMeta, DatMeta, DatMeta]:
+    rn_h = read_meta(out_dir / "ccw.rn_h.dat")
+    rn_t = read_meta(out_dir / "ccw.rn_t.dat")
+    factor = read_meta(out_dir / "ccw.rn_factor.dat")
+    return rn_h, rn_t, factor
+
+
+def format_meta(meta: DatMeta) -> str:
+    dt_part = f"{meta.dt_min:g} min" if meta.dt_min > 0 else "n/a"
+    return f"{meta.path.name}: rows={meta.num_records}, cols={meta.num_var}, dt={dt_part}, start={meta.start_time:g}"
+
+
+lines: list[str] = []
+
+try:
+    ensure_dir_nonempty(base_dir)
+    ensure_dir_nonempty(tsr_dir)
+
+    base_rn_h, base_rn_t, base_factor = case_metas(base_dir)
+    tsr_rn_h, tsr_rn_t, tsr_factor = case_metas(tsr_dir)
+
+    # Header parsing: rows/cols/dt + basic consistency checks.
+    for m in (base_rn_h, base_rn_t, base_factor, tsr_rn_h, tsr_rn_t, tsr_factor):
+        if m.dt_min <= 0 and m.num_records >= 2:
+            raise ValidationError(f"non-positive dt derived from {m.path}")
+        if m.num_records != expected_end_days * (24 * 60) // int(expected_dt_min):
+            raise ValidationError(
+                f"unexpected record count in {m.path.name}: got {m.num_records}, "
+                f"expected {expected_end_days * (24 * 60) // int(expected_dt_min)}"
+            )
+        if abs(m.dt_min - expected_dt_min) > 1e-9 and m.num_records >= 2:
+            raise ValidationError(f"unexpected dt in {m.path.name}: got {m.dt_min:g}, expected {expected_dt_min:g}")
+
+    # Baseline and TSR shapes must match.
+    if base_factor.num_var != tsr_factor.num_var or base_factor.num_records != tsr_factor.num_records:
+        raise ValidationError("baseline vs tsr shape mismatch in rn_factor")
+
+    base_hdr = "\n".join(header_lines(base_factor.header_text))
+    tsr_hdr = "\n".join(header_lines(tsr_factor.header_text))
+    if "Terrain radiation (TSR): OFF" not in base_hdr:
+        raise ValidationError("baseline header check failed: expected 'Terrain radiation (TSR): OFF'")
+    if "Terrain radiation (TSR): ON" not in tsr_hdr:
+        raise ValidationError("tsr header check failed: expected 'Terrain radiation (TSR): ON'")
+
+    # Numeric sanity: finite + non-zero payload + broad magnitude cap.
+    base_rn_h_stats = scan_stats(base_rn_h)
+    base_rn_t_stats = scan_stats(base_rn_t)
+    base_factor_stats = scan_stats(base_factor)
+    tsr_rn_h_stats = scan_stats(tsr_rn_h)
+    tsr_rn_t_stats = scan_stats(tsr_rn_t)
+    tsr_factor_stats = scan_stats(tsr_factor)
+
+    # Physics relation: rn_t ≈ rn_h * factor.
+    err_base = max_abs_err_relation(base_rn_h, base_rn_t, base_factor)
+    err_tsr = max_abs_err_relation(tsr_rn_h, tsr_rn_t, tsr_factor)
+    if err_base > 1e-9:
+        raise ValidationError(f"baseline rn_t != rn_h * factor (max abs err={err_base:.3e})")
+    if err_tsr > 1e-9:
+        raise ValidationError(f"tsr rn_t != rn_h * factor (max abs err={err_tsr:.3e})")
+
+    # Factor expectations.
+    base_factor_maxdev = max_abs_from_constant(base_factor, 1.0)
+    if base_factor_maxdev > 1e-9:
+        raise ValidationError(f"baseline factor not ~1 (max |f-1|={base_factor_maxdev:.3e})")
+
+    tsr_mn = tsr_factor_stats["min"]
+    tsr_mx = tsr_factor_stats["max"]
+    if tsr_mx <= 1.001:
+        raise ValidationError(f"tsr factor shows no variation (max={tsr_mx:.6f})")
+    if tsr_mn < -1e-12:
+        raise ValidationError(f"tsr factor has negative values (min={tsr_mn:.6f})")
+    if tsr_mx > 5.0 + 1e-6:
+        raise ValidationError(f"tsr factor exceeds RAD_FACTOR_CAP=5 (max={tsr_mx:.6f})")
+
+    # TSR=ON vs OFF must differ.
+    diff_factor = max_abs_diff(base_factor, tsr_factor)
+    diff_rn_t = max_abs_diff(base_rn_t, tsr_rn_t)
+    if diff_factor <= 1e-6 and diff_rn_t <= 1e-6:
+        raise ValidationError("baseline vs tsr outputs are unexpectedly identical")
+
+    lines.append("Validation: .dat header/shape")
+    lines.append(f"- expected END={expected_end_days} day(s), DT_QE_ET={expected_dt_min:g} min")
+    lines.append(f"- baseline {format_meta(base_factor)}")
+    lines.append(f"- tsr      {format_meta(tsr_factor)}")
+    lines.append("")
+    lines.append("Validation: numeric sanity (min/max)")
+    lines.append(f"- baseline rn_h  range=[{base_rn_h_stats['min']:.6g}, {base_rn_h_stats['max']:.6g}]")
+    lines.append(f"- baseline rn_t  range=[{base_rn_t_stats['min']:.6g}, {base_rn_t_stats['max']:.6g}]")
+    lines.append(f"- baseline factor range=[{base_factor_stats['min']:.6g}, {base_factor_stats['max']:.6g}]")
+    lines.append(f"- tsr rn_h       range=[{tsr_rn_h_stats['min']:.6g}, {tsr_rn_h_stats['max']:.6g}]")
+    lines.append(f"- tsr rn_t       range=[{tsr_rn_t_stats['min']:.6g}, {tsr_rn_t_stats['max']:.6g}]")
+    lines.append(f"- tsr factor     range=[{tsr_factor_stats['min']:.6g}, {tsr_factor_stats['max']:.6g}]")
+    lines.append("")
+    lines.append("Validation: physical relation & diff")
+    lines.append(f"- baseline: max |factor-1|={base_factor_maxdev:.3e}, rn_t=rn_h*factor err={err_base:.3e}")
+    lines.append(f"- tsr: factor range=[{tsr_mn:.6f}, {tsr_mx:.6f}], rn_t=rn_h*factor err={err_tsr:.3e}")
+    lines.append(f"- baseline vs tsr: max |factor_base-factor_tsr|={diff_factor:.3e}")
+    lines.append(f"- baseline vs tsr: max |rn_t_base-rn_t_tsr|={diff_rn_t:.3e}")
+    lines.append("")
+    lines.append("RESULT: PASS")
+    report_append(report_path, lines)
+    print("PASS: TSR integration validation")
+except ValidationError as e:
+    lines.append("RESULT: FAIL")
+    lines.append(f"Reason: {e}")
+    report_append(report_path, lines)
+    raise SystemExit(1)
+except Exception:
+    lines.append("RESULT: FAIL")
+    lines.append("Reason: unexpected exception while validating outputs")
+    lines.append(traceback.format_exc().rstrip())
+    report_append(report_path, lines)
+    raise SystemExit(1)
+PY

--- a/validation/tsr/run_baseline.sh
+++ b/validation/tsr/run_baseline.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+sd="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${sd}/_common.sh"
+
+run_ccw_case 0 "output/ccw.base" "validation/tsr/tmp/ccw.base" "baseline"

--- a/validation/tsr/run_tsr.sh
+++ b/validation/tsr/run_tsr.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+sd="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${sd}/_common.sh"
+
+run_ccw_case 1 "output/ccw.tsr" "validation/tsr/tmp/ccw.tsr" "tsr"

--- a/validation/tsr/test_report.txt
+++ b/validation/tsr/test_report.txt
@@ -1,0 +1,28 @@
+TSR Integration Test Report
+Timestamp: 2026-01-15T08:22:54Z
+Repo root: /Users/danker/Desktop/Hydro-SHUD/SHUD-up
+
+Step: run_baseline.sh: OK
+
+Step: run_tsr.sh: OK
+
+Validation: .dat header/shape
+- expected END=2 day(s), DT_QE_ET=60 min
+- baseline ccw.rn_factor.dat: rows=48, cols=1147, dt=60 min, start=2.00001e+07
+- tsr      ccw.rn_factor.dat: rows=48, cols=1147, dt=60 min, start=2.00001e+07
+
+Validation: numeric sanity (min/max)
+- baseline rn_h  range=[0, 441.233]
+- baseline rn_t  range=[0, 441.233]
+- baseline factor range=[1, 1]
+- tsr rn_h       range=[0, 441.233]
+- tsr rn_t       range=[0, 761.141]
+- tsr factor     range=[0, 5]
+
+Validation: physical relation & diff
+- baseline: max |factor-1|=0.000e+00, rn_t=rn_h*factor err=0.000e+00
+- tsr: factor range=[0.000000, 5.000000], rn_t=rn_h*factor err=3.411e-13
+- baseline vs tsr: max |factor_base-factor_tsr|=4.000e+00
+- baseline vs tsr: max |rn_t_base-rn_t_tsr|=4.412e+02
+
+RESULT: PASS


### PR DESCRIPTION
## Summary
Implements #13: TSR 验证框架，提供 TSR on/off 对照实验的可复现脚本。

## Changes

**New Structure**:
- `validation/tsr/` - TSR 验证框架目录
- 一条命令可复现 TSR 开关对比实验

**Scripts**:
- `run_baseline.sh`: TSR=OFF，输出到 `output/ccw.base/`
- `run_tsr.sh`: TSR=ON，输出到 `output/ccw.tsr/`
- `integration_test.sh`: 深度验证（header 解析 + 数值校验）

**Features**:
- ✅ 输入隔离：复制到 `validation/tsr/tmp/`
- ✅ 输出分离：两组输出互不覆盖
- ✅ 健壮错误处理：二进制/输入/输出检查
- ✅ 自动备份：已有输出目录自动重命名

## Testing

**Integration Test Result**: ✅ PASS

```
Physical Relation Validation:
- baseline: factor = 1.0 (TSR OFF, no terrain correction)
- tsr: factor ∈ [0, 5] (within RAD_FACTOR_CAP)
- rn_t = rn_h * factor (error < 1e-12)

TSR Effect Validation:
- max |factor_base - factor_tsr| = 4.0
- max |rn_t_base - rn_t_tsr| = 441.2 W/m²
```

## Documentation
- `validation/tsr/README.md` - 使用说明和故障排查指南
- `.claude/specs/issue-13-tsr-validation-scripts/dev-plan.md` - 开发计划文档

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)