### PR TITLE
docs(D1): align model_upgrade As-Is vs To-Be

### DIFF
--- a/docs/model_upgrade.md
+++ b/docs/model_upgrade.md
@@ -1,0 +1,81 @@
+# Model Upgrade：As-Is（当前实现） vs To-Be（计划实现）
+
+本文档用于把“规划/设想”与“仓库当前真实实现”明确区分，避免新读者把计划误读为已完成。
+
+- **As-Is（当前实现）**：以 `src/` 为准（本文中的 As-Is 结论均可在源码中定位）。
+- **To-Be（计划实现）**：以 `docs/spec.md` 与 `epic/`（Epic backlog）为准。
+
+## 文档入口（必读）
+
+- 计划与范围（Spec）：[`docs/spec.md`](spec.md)
+- Epic backlog（需求拆分与追踪）：[`epic/README.md`](../epic/README.md)
+- TSR 验证（已完成工作）：[`validation/tsr/README.md`](../validation/tsr/README.md)
+- TSR 物理假设与尺度限制（背景）：[`TSR_Physical_Assumptions.md`](../TSR_Physical_Assumptions.md)
+
+## Current Status (As-Is)
+
+> 本节描述“现在仓库里已经有什么”，以 `src/` 与 `validation/` 为准。
+
+### 1) Terrain Solar Radiation (TSR) 开关与计算链路
+
+**现状：已实现（可用）**
+
+- **开关**：`TERRAIN_RADIATION`（0/1），在参数文件中配置后生效。
+- **太阳位置更新间隔**：`SOLAR_UPDATE_INTERVAL`（分钟）；太阳位置与因子缓存按时间桶更新。
+- **数值边界参数**：
+  - `RAD_FACTOR_CAP`：TSR 因子上限（防止极端几何导致放大过大）
+  - `RAD_COSZ_MIN`：分母 `cosZ` 的下限截断（避免日出/日落附近数值发散）
+- **短波辐射输入语义**：`RADIATION_INPUT_MODE`
+  - `SWDOWN`（默认）：forcing 第 6 列为下行短波，模型内部会再乘 `(1 - Albedo)` 得到净短波
+  - `SWNET`：forcing 第 6 列已是净短波，不再乘 `(1 - Albedo)`
+- **全局太阳经纬度选择**：`SOLAR_LONLAT_MODE`
+  - `FORCING_FIRST`（默认）：使用 forcing 列表第一个站点的经纬度
+  - `FORCING_MEAN`：对 forcing 列表中有效经纬度取均值
+  - `FIXED`：使用 `SOLAR_LON_DEG` / `SOLAR_LAT_DEG`
+- **时间基准与时区约定**：
+  - 基准日期来自 forcing 列表头部的 `ForcStartTime`（`YYYYMMDD`），用于计算儒略日/太阳几何
+  - TSR 的太阳位置计算按 UTC 对齐（显式传入 `timezone_hours=0.0`），避免由经度推断时区造成相位偏移
+
+**源码入口（可定位）**
+
+- 辐射读取与 TSR 因子应用：`src/ModelData/MD_ET.cpp`
+- 太阳位置与地形因子：`src/Equations/SolarRadiation.cpp`、`src/Equations/SolarRadiation.hpp`
+- 基准日期/儒略日（供太阳几何使用）：`src/classes/TimeContext.cpp`、`src/classes/TimeContext.hpp`
+- 单元地形法向量/坡度/坡向：`src/classes/Element.cpp`、`src/classes/Element.hpp`
+- 参数解析与输出头信息：`src/classes/Model_Control.cpp`、`src/classes/Model_Control.hpp`
+
+### 2) TSR 相关输出（用于诊断/验证）
+
+**现状：已实现（可用）**
+
+- 当 `DT_QE_ET > 0`（启用 element ET 输出）时，会额外输出三类 TSR 诊断量：
+  - `*.rn_h`：水平面短波（forcing 原值，W/m²）
+  - `*.rn_t`：地形修正后短波（W/m²）
+  - `*.rn_factor`：TSR 因子（无量纲）
+- 输出文件既支持二进制 `.dat`（默认）也支持 ASCII `.csv`（取决于 `ASCII/BINARY` 配置）。
+- **时间戳语义**：输出时间采用区间左端点（`t - Interval`），值为该输出区间内的**均值**（见 `Print_Ctrl::PrintData`）。
+
+### 3) TSR 验证现状（已完成工作）
+
+**现状：已完成一套可复现实证/回归流程**
+
+- `validation/tsr/` 提供 baseline（TSR=OFF）与 TSR=ON 的端到端运行脚本与深度校验：
+  - 目录说明与使用方法：[`validation/tsr/README.md`](../validation/tsr/README.md)
+  - Python 参考实现（`.dat` 读取 + TSR 计算对照）与单元测试：[`validation/tsr/py/`](../validation/tsr/py/)
+
+### 4) 明确“当前没有”的内容（避免误读）
+
+以下内容**在当前仓库中并未实现**（若在其他文档中出现，应视为 To-Be/提案，或需要补充实现后再宣称“已完成”）：
+
+- **分布式太阳位置**（例如“每个 element 使用自身中心点经纬度计算太阳位置”）：当前 TSR 使用单个全局太阳位置近似。
+- **地形遮蔽/地平线遮挡（horizon/shadowing）**：当前 `terrainFactor()` 为坡面入射几何修正，不包含视域/遮挡建模。
+- **C++ 单元测试框架/`tests/` 目录**：当前主要采用 `validation/` 下的脚本与 Python `unittest` 做验证。
+
+## Planned Features (To-Be)
+
+> 本节描述“计划做什么”，不代表已经实现；请以 `docs/spec.md` 与 `epic/README.md` 为准。
+
+- 计划与需求基线：[`docs/spec.md`](spec.md)
+- 任务拆分与追踪（Epic backlog）：[`epic/README.md`](../epic/README.md)
+
+为避免 To-Be 与 As-Is 混淆，本文档仅保留摘要；所有 To-Be 的细节、边界条件与验收标准请在上述两处维护。

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1,0 +1,45 @@
+# SHUD-up Spec（To-Be / Draft）
+
+本文件描述 **To-Be（计划实现）**：我们希望 SHUD-up 在后续迭代中达成的目标与约束。
+
+- **当前实现（As-Is）**：请以 [`docs/model_upgrade.md`](model_upgrade.md) 的 As-Is 部分与 `src/` 为准。
+- **任务拆分与追踪（Epic backlog）**：请以 [`epic/README.md`](../epic/README.md) 为准。
+
+## 目标（Goals）
+
+- 让 TSR（Terrain Shortwave Radiation）能力“可解释、可配置、可验证”，并且在不引入过高计算开销的前提下提升适用范围。
+- 让关键输出具备可追溯性（运行时能知道关键开关/经纬度选择等元数据），便于复现实验与回归比较。
+- 形成持续可用的验证基线（validation workflow），将“研究原型”沉淀为可复现流程。
+
+## 非目标（Non-goals）
+
+- 不在短期内引入完整辐射传输/遮蔽/地平线视域等重物理模型（如需应另立 Epic）。
+- 不强制引入新的 C++ 测试框架；当前以 `validation/` 工作流为主（如需 CI 化应另立 Epic）。
+
+## To-Be：计划功能与改进方向（摘要）
+
+> 具体拆分到 issue 的粒度与优先级由 Epic backlog 管理；此处仅给出方向与边界。
+
+### 1) TSR：太阳位置空间分布能力
+
+现状使用“单个全局太阳位置”近似（见 [`TSR_Physical_Assumptions.md`](../TSR_Physical_Assumptions.md)），计划提供可选的更高精度模式：
+
+- **分区/分带太阳位置**：对流域划分少量区域，每区计算独立太阳位置与/或 TSR 因子，用插值或分配方式作用到单元，兼顾精度与性能。
+- **ELEMENT_CENTER（提案）**：每个 element 使用自身中心点经纬度计算太阳位置，并保留时间桶更新策略控制开销。
+  - 前置条件：需要明确 element 的经纬度来源（例如输入数据提供，或定义投影与转换方法）。
+
+### 2) TSR：参数与边界行为明确化
+
+- 继续保持关键参数可配置（例如 `SOLAR_UPDATE_INTERVAL`、`RAD_FACTOR_CAP`、`RAD_COSZ_MIN`）。
+- 对低太阳高度角附近的边界行为（例如 `RAD_COSZ_MIN` 截断导致的数值特性）在文档中给出明确解释与建议默认值范围。
+
+### 3) 验证与回归（Validation / Regression）
+
+- 扩展 [`validation/tsr/`](../validation/tsr/) 覆盖更多示例流域/工况，形成“可重复跑”的回归集合。
+- 为关键数值关系定义验收规则（例如“TSR=ON 输出应与 OFF 有显著差异，但形状/维度一致”），并在脚本中固化。
+- 如引入 CI（可选）：优先做“轻量级”校验（小步长/短时间窗），避免拉长构建时间。
+
+### 4) 文档一致性（Docs）
+
+- `docs/model_upgrade.md` 始终保持 As-Is/To-Be 对齐：As-Is 以 `src/` 为准；To-Be 以本 spec 与 Epic backlog 为准。
+- 对“尚未实现/未来提案/待定”的内容必须显式标注，避免误导新读者。

--- a/epic/README.md
+++ b/epic/README.md
@@ -1,0 +1,29 @@
+# Epic backlog（规划任务清单）
+
+本目录用于维护 SHUD-up 的 **Epic backlog**：把 `docs/spec.md` 中的 To-Be 目标拆分为可执行的 issue，并持续追踪进度。
+
+- 计划基线（Spec）：[`docs/spec.md`](../docs/spec.md)
+- 当前实现（As-Is）：[`docs/model_upgrade.md`](../docs/model_upgrade.md)
+
+## Backlog 维护方式
+
+目前采用“以 Markdown 文件为单元”的方式维护 backlog，并可用脚本批量创建 GitHub issues：
+
+- Backlog 文件命名：`epic/backlog-*.md`
+  - 文件首行 `# ...` 作为 issue 标题
+  - 其余内容作为 issue body
+- 创建 issues 脚本：`epic/create_issues_from_backlog.sh`
+  - 依赖：`gh`（GitHub CLI）已登录、`git`
+  - 会为每个 `backlog-*.md` 创建一个 issue
+  - 会在 `epic/issue-map.tsv` 记录 “文件路径 -> issue URL -> issue number” 的映射（自动生成）
+
+运行示例（在仓库根目录）：
+
+```bash
+bash epic/create_issues_from_backlog.sh
+```
+
+## 注意事项
+
+- 本目录下的 `issue-map.tsv` 为脚本生成产物；是否提交到仓库由团队约定决定。
+- 若仓库中暂时没有 `backlog-*.md` 文件：表示 backlog 可能仍在 GitHub issues/看板中维护，后续再逐步回填到本目录以实现“文档即 backlog”。

--- a/epic/create_issues_from_backlog.sh
+++ b/epic/create_issues_from_backlog.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+MAP_FILE="epic/issue-map.tsv"
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "ERROR: missing command: $1" >&2
+    exit 1
+  }
+}
+
+require_cmd gh
+require_cmd git
+require_cmd find
+require_cmd sort
+require_cmd head
+
+if ! gh auth status -h github.com >/dev/null 2>&1; then
+  echo "ERROR: gh not authenticated (or token invalid)." >&2
+  echo "Run: gh auth login -h github.com" >&2
+  exit 1
+fi
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "ERROR: not inside a git repository." >&2
+  exit 1
+fi
+
+mapped_url_for_file() {
+  local file="$1"
+  [[ -f "$MAP_FILE" ]] || return 1
+  awk -F $'\t' -v f="$file" '$1 == f {print $2; found=1; exit} END {exit(found?0:1)}' "$MAP_FILE"
+}
+
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+
+find epic -type f -name 'backlog-*.md' | sort >"$tmp"
+
+touch "$MAP_FILE"
+
+while IFS= read -r file; do
+  if url_existing="$(mapped_url_for_file "$file" 2>/dev/null)"; then
+    echo "SKIP: already mapped: $file -> $url_existing"
+    continue
+  fi
+  title="$(head -n 1 "$file" | sed 's/^# *//')"
+  echo "CREATE: $title"
+  url="$(gh issue create --title "$title" --body-file "$file")"
+  number="${url##*/}"
+  printf "%s\t%s\t%s\n" "$file" "$url" "$number" >>"$MAP_FILE"
+  echo "OK: $url"
+done <"$tmp"
+
+echo "Done. Issue map written to: $MAP_FILE"


### PR DESCRIPTION
## Summary
Implements #17

## Changes
- **Updated `docs/model_upgrade.md`**: Clear As-Is/To-Be distinction
  - As-Is: Current implementation status (with src/ references)
  - To-Be: Planned features (with links to docs/spec.md and epic/)
  - No misleading "already implemented" claims
- **Added `docs/spec.md`**: To-Be planning baseline for reference
- **Added `epic/README.md`**: Epic backlog explanation and maintenance workflow
- **Added `epic/create_issues_from_backlog.sh`**: Issue creation script (for reference integrity)

## Documentation Structure
```
docs/model_upgrade.md  → As-Is vs To-Be entry point
    ├─→ docs/spec.md   (To-Be spec)
    └─→ epic/          (backlog management)
```

## Verification
- Cross-checked all claims against src/ files
- All markdown links validated
- No references to non-existent files/features

Closes #17