### PR TITLE
[A1] Refactor forcing access behind ForcingProvider abstraction

### DIFF
--- a/src/ModelData/MD_update.cpp
+++ b/src/ModelData/MD_update.cpp
@@ -2,7 +2,10 @@
 
 void Model_Data::updateAllTimeSeries(double t_min)
 {
-    if (NumForc > 0 && tsd_weather != nullptr) {
+    if (NumForc > 0 && forcing != nullptr) {
+        forcing->movePointer(t_min);
+    } else if (NumForc > 0 && tsd_weather != nullptr) {
+        // Legacy fallback (should not happen once forcing provider is initialized).
         for (int i = 0; i < NumForc; i++) {
             tsd_weather[i].movePointer(t_min);
         }

--- a/src/ModelData/Model_Data.hpp
+++ b/src/ModelData/Model_Data.hpp
@@ -9,6 +9,7 @@
 #include <stdio.h>
 #include <vector>
 #include "TimeSeriesData.hpp"
+#include "ForcingProvider.hpp"
 #include "ModelConfigure.hpp"
 #include "IO.hpp"
 #include "River.hpp"
@@ -73,6 +74,7 @@ public:
     int *io_ele, *io_riv, *io_lake; /* Wether Export the data of these elements */
     
     _TimeSeriesData *tsd_weather;
+    ForcingProvider *forcing = nullptr;
     _TimeSeriesData tsd_LAI;
 //    _TimeSeriesData tsd_RL;
     _TimeSeriesData tsd_MF;
@@ -326,6 +328,7 @@ private:
     void read_soil(const char *fn);
     void read_geol(const char *fn);
     void read_lc(const char *fn);
+    void read_forc(const char *fn);
     void read_forc_csv(const char *fn);
 //    void read_rl(const char *fn);
     void read_lai(const char *fn);

--- a/src/classes/ForcingProvider.hpp
+++ b/src/classes/ForcingProvider.hpp
@@ -1,0 +1,71 @@
+//  ForcingProvider.hpp
+//  SHUD
+//
+//  Forcing provider abstraction for supporting multiple forcing sources
+//  (baseline CSV today; NetCDF in Phase A).
+//
+//  The forcing contract is the existing SHUD 5-variable forcing set:
+//    Precip(mm/day), Temp(C), RH(0-1), Wind(m/s), RN(W/m2)
+//
+#ifndef ForcingProvider_hpp
+#define ForcingProvider_hpp
+
+#include "TimeSeriesData.hpp"
+
+class ForcingProvider {
+public:
+    virtual ~ForcingProvider() = default;
+
+    virtual int numStations() const = 0;
+    virtual void movePointer(double t_min) = 0;
+
+    // Step-function semantics: return the current-interval value after movePointer(t_min).
+    // Column indices follow SHUD forcing macros: i_prcp..i_rn (1..5).
+    virtual double get(int station_idx, int column) const = 0;
+
+    // Forcing interval bounds (minutes) for the active pointer (used by TSR).
+    virtual double currentTimeMin(int station_idx) const = 0;
+    virtual double nextTimeMin(int station_idx) const = 0;
+
+    // Station metadata (lon/lat in degrees; z in meters)
+    virtual double lon(int station_idx) const = 0;
+    virtual double lat(int station_idx) const = 0;
+    virtual double z(int station_idx) const = 0;
+};
+
+class CsvForcingProvider final : public ForcingProvider {
+public:
+    CsvForcingProvider(_TimeSeriesData *tsd_weather, int num_forc)
+        : tsd_weather_(tsd_weather), num_forc_(num_forc) {}
+
+    int numStations() const override { return num_forc_; }
+
+    void movePointer(double t_min) override
+    {
+        if (tsd_weather_ == nullptr || num_forc_ <= 0) {
+            return;
+        }
+        for (int i = 0; i < num_forc_; i++) {
+            tsd_weather_[i].movePointer(t_min);
+        }
+    }
+
+    double get(int station_idx, int column) const override
+    {
+        return tsd_weather_[station_idx].getX(0.0, column);
+    }
+
+    double currentTimeMin(int station_idx) const override { return tsd_weather_[station_idx].currentTimeMin(); }
+    double nextTimeMin(int station_idx) const override { return tsd_weather_[station_idx].nextTimeMin(); }
+
+    double lon(int station_idx) const override { return tsd_weather_[station_idx].lon(); }
+    double lat(int station_idx) const override { return tsd_weather_[station_idx].lat(); }
+    double z(int station_idx) const override { return tsd_weather_[station_idx].xyz[2]; }
+
+private:
+    _TimeSeriesData *tsd_weather_ = nullptr;
+    int num_forc_ = 0;
+};
+
+#endif /* ForcingProvider_hpp */
+


### PR DESCRIPTION
Closes #44

## Summary
- Introduce `ForcingProvider` abstraction with a `CsvForcingProvider` wrapper around the existing `_TimeSeriesData` forcing workflow.
- Route forcing pointer advance (`Model_Data::updateAllTimeSeries`) and forcing reads (`Model_Data::tReadForcing`) through the provider interface.
- Add `Model_Data::read_forc()` as a forcing-mode dispatch point (NetCDF path is a fail-fast stub until #46).

## Tests
- `make shud`
- Smoke run: `./shud ccw` with a temporary short `START/END` window
