### PR TITLE
[B0] Parse OUTPUT_MODE/NCOUTPUT_CFG in cfg.para

### DIFF
--- a/src/classes/Model_Control.hpp
+++ b/src/classes/Model_Control.hpp
@@ -27,6 +27,12 @@ enum ForcingMode{
     FORCING_NETCDF = 1
 };
 
+enum OutputMode{
+    OUTPUT_LEGACY = 0,
+    OUTPUT_NETCDF = 1,
+    OUTPUT_BOTH = 2
+};
+
 static inline const char* SolarLonLatModeName(SolarLonLatMode mode)
 {
     switch (mode) {
@@ -122,6 +128,8 @@ private:
 public:
     ForcingMode forcing_mode = FORCING_CSV; /* FORCING_MODE: CSV (default) or NETCDF */
     char forcing_cfg[MAXLEN] = "";          /* FORCING_CFG: path (required when FORCING_MODE=NETCDF) */
+    OutputMode output_mode = OUTPUT_LEGACY; /* OUTPUT_MODE: LEGACY (default), NETCDF, or BOTH */
+    char ncoutput_cfg[MAXLEN] = "";         /* NCOUTPUT_CFG: path (required when OUTPUT_MODE includes NETCDF) */
     int Verbose = 0;
     int CloseBoundary = 1; /* Whether the close boundary exist. 1 = no boundary flux. 0 = Default boundary flux. [bool]*/
     int Ascii = 0;      /* Whether export result as ASCII File [bool]*/


### PR DESCRIPTION
Links: closes DankerMu/SHUD-up#48

OpenSpec change id: `add-shud-output-mode-config`
- Proposal: https://github.com/DankerMu/SHUD-NC/blob/main/openspec/changes/add-shud-output-mode-config/proposal.md
- Tasks: https://github.com/DankerMu/SHUD-NC/blob/main/openspec/changes/add-shud-output-mode-config/tasks.md
- Spec delta: https://github.com/DankerMu/SHUD-NC/blob/main/openspec/changes/add-shud-output-mode-config/specs/shud-output/spec.md

## Summary
- Add `.cfg.para` parsing for `OUTPUT_MODE` (default LEGACY; allowed: LEGACY/NETCDF/BOTH).
- Add `.cfg.para` parsing + validation for `NCOUTPUT_CFG` when `OUTPUT_MODE` includes NetCDF.
- Resolve relative `NCOUTPUT_CFG` paths relative to the input directory and fail-fast if unreadable.

## Tests
- `make shud`
