### PR TITLE
[B3] NetCDF output: write UGRID mesh in element file

### DIFF
--- a/src/ModelData/MD_initialize.cpp
+++ b/src/ModelData/MD_initialize.cpp
@@ -344,7 +344,7 @@ void Model_Data:: initialize_output (){
 
 #ifdef _NETCDF_ON
     if (CS.output_mode == OUTPUT_NETCDF || CS.output_mode == OUTPUT_BOTH) {
-        ncoutput = std::make_unique<NetcdfOutputContext>(CS.ncoutput_cfg);
+        ncoutput = std::make_unique<NetcdfOutputContext>(CS.ncoutput_cfg, Node, NumNode, Ele, NumEle);
         for (int i = 0; i < CS.NumPrint; i++) {
             if (CS.PCtrl[i].numAll() == NumEle) {
                 CS.PCtrl[i].setSink(ncoutput->createElementSink());

--- a/src/classes/NetcdfOutputContext.hpp
+++ b/src/classes/NetcdfOutputContext.hpp
@@ -11,10 +11,16 @@
 #include <memory>
 
 class IPrintSink;
+class _Element;
+class _Node;
 
 class NetcdfOutputContext {
 public:
-    explicit NetcdfOutputContext(const char *ncoutput_cfg_path);
+    NetcdfOutputContext(const char *ncoutput_cfg_path,
+                        const _Node *nodes,
+                        int num_nodes,
+                        const _Element *elements,
+                        int num_elements);
     ~NetcdfOutputContext();
 
     IPrintSink *createElementSink();
@@ -27,4 +33,3 @@ private:
 #endif /* _NETCDF_ON */
 
 #endif /* NetcdfOutputContext_hpp */
-


### PR DESCRIPTION
Links: closes #51

Summary:
- Write UGRID mesh topology + connectivity variables into `<prefix>.ele.nc`:
  - dimensions: `mesh_node`, `mesh_face`, `max_face_nodes=3`
  - variables: `mesh_node_x/y`, `mesh_face_nodes` (`start_index=1`), `mesh_face_x/y`, topology variable `mesh` (`cf_role=mesh_topology`)
- Attach `mesh/location/coordinates` attributes to element data variables.

Tests:
- `make clean && make shud NETCDF=1`
- Short-run QHH (OUTPUT_MODE=BOTH): verified `ncdump -h <out_dir>/qhh.ele.nc` includes UGRID vars + attributes.
