### PR TITLE
[B4] NetCDF output: add riv/lake files

### DIFF
--- a/src/ModelData/MD_initialize.cpp
+++ b/src/ModelData/MD_initialize.cpp
@@ -348,6 +348,10 @@ void Model_Data:: initialize_output (){
         for (int i = 0; i < CS.NumPrint; i++) {
             if (CS.PCtrl[i].numAll() == NumEle) {
                 CS.PCtrl[i].setSink(ncoutput->createElementSink());
+            } else if (NumRiv > 0 && CS.PCtrl[i].numAll() == NumRiv) {
+                CS.PCtrl[i].setSink(ncoutput->createRiverSink());
+            } else if (NumLake > 0 && CS.PCtrl[i].numAll() == NumLake) {
+                CS.PCtrl[i].setSink(ncoutput->createLakeSink());
             }
         }
     }

--- a/src/classes/NetcdfOutputContext.cpp
+++ b/src/classes/NetcdfOutputContext.cpp
@@ -498,6 +498,194 @@ private:
     std::vector<double> times_;
 };
 
+class NetcdfSimpleFile {
+public:
+    NetcdfSimpleFile(std::string out_dir_abs,
+                     float fill_value,
+                     std::string obj_dim_name,
+                     std::string obj_id_var_name,
+                     std::string file_suffix)
+        : out_dir_abs_(std::move(out_dir_abs)),
+          fill_value_(fill_value),
+          obj_dim_name_(std::move(obj_dim_name)),
+          obj_id_var_name_(std::move(obj_id_var_name)),
+          file_suffix_(std::move(file_suffix))
+    {
+    }
+
+    ~NetcdfSimpleFile() { close(); }
+
+    void openIfNeeded(const char *legacy_basename, long forc_start_yyyymmdd, int n_all)
+    {
+        if (ncid_ != -1) {
+            if (n_all_ != n_all || forc_start_yyyymmdd_ != forc_start_yyyymmdd) {
+                fprintf(stderr, "\n  Fatal Error: Inconsistent NetCDF output context.\n");
+                fprintf(stderr, "  Existing: n_all=%d ForcStartTime=%ld\n", n_all_, forc_start_yyyymmdd_);
+                fprintf(stderr, "  New:      n_all=%d ForcStartTime=%ld\n", n_all, forc_start_yyyymmdd);
+                myexit(ERRFileIO);
+            }
+            return;
+        }
+
+        if (n_all <= 0) {
+            fprintf(stderr, "\n  Fatal Error: Invalid output dimension for NetCDF output (%s).\n", obj_dim_name_.c_str());
+            fprintf(stderr, "  n_all: %d\n", n_all);
+            myexit(ERRFileIO);
+        }
+
+        n_all_ = n_all;
+        forc_start_yyyymmdd_ = forc_start_yyyymmdd;
+
+        const std::string prefix_leaf = derivePrefixLeaf(legacy_basename);
+
+        std::string out_dir = out_dir_abs_.empty() ? dirnameOf(std::string(legacy_basename)) : out_dir_abs_;
+        if (out_dir.empty()) {
+            out_dir = ".";
+        }
+
+        std::vector<char> out_dir_mut(out_dir.begin(), out_dir.end());
+        out_dir_mut.push_back('\0');
+        mkdir_p(out_dir_mut.data(), 0777);
+
+        file_path_ = joinPath(out_dir, prefix_leaf + file_suffix_);
+
+        const int cmode = NC_NETCDF4 | NC_CLASSIC_MODEL | NC_CLOBBER;
+        ncCheck(nc_create(file_path_.c_str(), cmode, &ncid_), "nc_create", file_path_.c_str());
+
+        ncCheck(nc_def_dim(ncid_, "time", NC_UNLIMITED, &dim_time_), "nc_def_dim(time)", file_path_.c_str());
+        ncCheck(nc_def_dim(ncid_, obj_dim_name_.c_str(), (size_t)n_all_, &dim_obj_),
+                "nc_def_dim(object)",
+                file_path_.c_str());
+
+        const int time_dims[1] = {dim_time_};
+        ncCheck(nc_def_var(ncid_, "time", NC_DOUBLE, 1, time_dims, &var_time_), "nc_def_var(time)", file_path_.c_str());
+
+        const std::string iso = isoDateFromYYYYMMDD(forc_start_yyyymmdd_);
+        const std::string units = "minutes since " + iso + " 00:00:00 UTC";
+        ncCheck(nc_put_att_text(ncid_, var_time_, "units", units.size(), units.c_str()),
+                "nc_put_att_text(time.units)",
+                file_path_.c_str());
+        const char *calendar = "standard";
+        ncCheck(nc_put_att_text(ncid_, var_time_, "calendar", strlen(calendar), calendar),
+                "nc_put_att_text(time.calendar)",
+                file_path_.c_str());
+
+        const int obj_dims[1] = {dim_obj_};
+        ncCheck(nc_def_var(ncid_, obj_id_var_name_.c_str(), NC_INT, 1, obj_dims, &var_obj_id_),
+                "nc_def_var(object_id)",
+                file_path_.c_str());
+        const int start_index = 1;
+        ncCheck(nc_put_att_int(ncid_, var_obj_id_, "start_index", NC_INT, 1, &start_index),
+                "nc_put_att_int(object_id.start_index)",
+                file_path_.c_str());
+
+        const char *conventions = "CF-1.10 UGRID-1.0";
+        ncCheck(nc_put_att_text(ncid_, NC_GLOBAL, "Conventions", strlen(conventions), conventions),
+                "nc_put_att_text(global.Conventions)",
+                file_path_.c_str());
+
+        ncCheck(nc_enddef(ncid_), "nc_enddef", file_path_.c_str());
+
+        std::vector<int> ids((size_t)n_all_, 0);
+        for (int i = 0; i < n_all_; i++) {
+            ids[(size_t)i] = i + 1;
+        }
+        ncCheck(nc_put_var_int(ncid_, var_obj_id_, ids.data()), "nc_put_var_int(object_id)", file_path_.c_str());
+    }
+
+    int ensureVar(const std::string &name)
+    {
+        const auto it = varids_.find(name);
+        if (it != varids_.end()) {
+            return it->second;
+        }
+        if (ncid_ == -1) {
+            fprintf(stderr, "\n  Fatal Error: NetCDF output file is not initialized before defining variables.\n");
+            myexit(ERRFileIO);
+        }
+
+        ncCheck(nc_redef(ncid_), "nc_redef", file_path_.c_str());
+        const int dims[2] = {dim_time_, dim_obj_};
+        int varid = -1;
+        ncCheck(nc_def_var(ncid_, name.c_str(), NC_FLOAT, 2, dims, &varid),
+                "nc_def_var(data)",
+                file_path_.c_str());
+        ncCheck(nc_put_att_float(ncid_, varid, "_FillValue", NC_FLOAT, 1, &fill_value_),
+                "nc_put_att_float(_FillValue)",
+                file_path_.c_str());
+        ncCheck(nc_enddef(ncid_), "nc_enddef", file_path_.c_str());
+
+        varids_[name] = varid;
+        return varid;
+    }
+
+    size_t ensureTimeIndex(long long t_min)
+    {
+        const auto it = time_to_idx_.find(t_min);
+        if (it != time_to_idx_.end()) {
+            return it->second;
+        }
+        if (ncid_ == -1) {
+            fprintf(stderr, "\n  Fatal Error: NetCDF output file is not initialized before writing time.\n");
+            myexit(ERRFileIO);
+        }
+
+        const size_t idx = times_.size();
+        times_.push_back((double)t_min);
+        time_to_idx_[t_min] = idx;
+
+        const size_t start[1] = {idx};
+        const double v = (double)t_min;
+        ncCheck(nc_put_var1_double(ncid_, var_time_, start, &v), "nc_put_var1_double(time)", file_path_.c_str());
+        return idx;
+    }
+
+    void writeVar(int varid, size_t time_idx, const std::vector<float> &data)
+    {
+        if (ncid_ == -1) {
+            fprintf(stderr, "\n  Fatal Error: NetCDF output file is not initialized before writing data.\n");
+            myexit(ERRFileIO);
+        }
+        if ((int)data.size() != n_all_) {
+            fprintf(stderr, "\n  Fatal Error: NetCDF write buffer size mismatch.\n");
+            fprintf(stderr, "  Expected n_all=%d, got=%zu\n", n_all_, data.size());
+            myexit(ERRFileIO);
+        }
+
+        const size_t start[2] = {time_idx, 0};
+        const size_t count[2] = {1, (size_t)n_all_};
+        ncCheck(nc_put_vara_float(ncid_, varid, start, count, data.data()), "nc_put_vara_float(data)", file_path_.c_str());
+    }
+
+    void close()
+    {
+        if (ncid_ != -1) {
+            nc_close(ncid_);
+            ncid_ = -1;
+        }
+    }
+
+private:
+    std::string out_dir_abs_;
+    float fill_value_ = 9.96921e36f;
+    std::string obj_dim_name_;
+    std::string obj_id_var_name_;
+    std::string file_suffix_;
+
+    std::string file_path_;
+    int ncid_ = -1;
+    int dim_time_ = -1;
+    int dim_obj_ = -1;
+    int var_time_ = -1;
+    int var_obj_id_ = -1;
+    int n_all_ = 0;
+    long forc_start_yyyymmdd_ = 0;
+
+    std::map<std::string, int> varids_;
+    std::map<long long, size_t> time_to_idx_;
+    std::vector<double> times_;
+};
+
 class NetcdfElementVarSink final : public IPrintSink {
 public:
     explicit NetcdfElementVarSink(NetcdfElementFile *file) : file_(file) {}
@@ -564,6 +752,72 @@ private:
     std::vector<int> icol_;
 };
 
+class NetcdfSimpleVarSink final : public IPrintSink {
+public:
+    explicit NetcdfSimpleVarSink(NetcdfSimpleFile *file) : file_(file) {}
+
+    void onInit(const char *legacy_basename,
+                long start_yyyymmdd,
+                int interval_min,
+                int n_all,
+                int num_selected,
+                const double *icol_1based,
+                int /* radiation_input_mode */,
+                int /* terrain_radiation */,
+                int /* solar_lonlat_mode */,
+                double /* solar_lon_deg */,
+                double /* solar_lat_deg */) override
+    {
+        (void)interval_min;
+        var_name_ = deriveVarName(legacy_basename);
+        n_all_ = n_all;
+        icol_.clear();
+        icol_.reserve((size_t)std::max(0, num_selected));
+        for (int i = 0; i < num_selected; i++) {
+            icol_.push_back((int)llround(icol_1based[i]));
+        }
+
+        file_->openIfNeeded(legacy_basename, start_yyyymmdd, n_all_);
+        varid_ = file_->ensureVar(var_name_);
+        initialized_ = true;
+    }
+
+    void onWrite(double t_quantized_min, int num_selected, const double *buffer) override
+    {
+        if (!initialized_ || file_ == nullptr || buffer == nullptr) {
+            return;
+        }
+
+        const long long t_min = (long long)llround(t_quantized_min);
+        const size_t time_idx = file_->ensureTimeIndex(t_min);
+
+        std::vector<float> out((size_t)n_all_, fill_value_);
+        const int nsel = std::min<int>(num_selected, (int)icol_.size());
+        for (int j = 0; j < nsel; j++) {
+            const int idx0 = icol_[(size_t)j] - 1;
+            if (idx0 < 0 || idx0 >= n_all_) {
+                continue;
+            }
+            out[(size_t)idx0] = (float)buffer[j];
+        }
+
+        file_->writeVar(varid_, time_idx, out);
+    }
+
+    void onClose() override {}
+
+private:
+    NetcdfSimpleFile *file_ = nullptr;
+    bool initialized_ = false;
+
+    std::string var_name_;
+    int varid_ = -1;
+    int n_all_ = 0;
+    float fill_value_ = 9.96921e36f;
+
+    std::vector<int> icol_;
+};
+
 struct ParsedNcOutputCfg {
     std::string schema_abs;
     std::string out_dir_abs;
@@ -605,18 +859,38 @@ struct NetcdfOutputContext::Impl {
     std::string ncoutput_cfg_path;
     ParsedNcOutputCfg cfg;
     NetcdfElementFile ele_file;
+    NetcdfSimpleFile riv_file;
+    NetcdfSimpleFile lake_file;
     std::vector<std::unique_ptr<IPrintSink>> sinks;
 
     Impl(const char *path, const _Node *nodes, int num_nodes, const _Element *elements, int num_elements)
         : ncoutput_cfg_path(path ? path : ""),
           cfg(parseNcOutputCfg(ncoutput_cfg_path)),
-          ele_file(cfg.out_dir_abs, 9.96921e36f, nodes, num_nodes, elements, num_elements)
+          ele_file(cfg.out_dir_abs, 9.96921e36f, nodes, num_nodes, elements, num_elements),
+          riv_file(cfg.out_dir_abs, 9.96921e36f, "river", "river_id", ".riv.nc"),
+          lake_file(cfg.out_dir_abs, 9.96921e36f, "lake", "lake_id", ".lake.nc")
     {
     }
 
     IPrintSink *createElementSink()
     {
         auto s = std::make_unique<NetcdfElementVarSink>(&ele_file);
+        IPrintSink *ptr = s.get();
+        sinks.push_back(std::move(s));
+        return ptr;
+    }
+
+    IPrintSink *createRiverSink()
+    {
+        auto s = std::make_unique<NetcdfSimpleVarSink>(&riv_file);
+        IPrintSink *ptr = s.get();
+        sinks.push_back(std::move(s));
+        return ptr;
+    }
+
+    IPrintSink *createLakeSink()
+    {
+        auto s = std::make_unique<NetcdfSimpleVarSink>(&lake_file);
         IPrintSink *ptr = s.get();
         sinks.push_back(std::move(s));
         return ptr;
@@ -637,6 +911,16 @@ NetcdfOutputContext::~NetcdfOutputContext() = default;
 IPrintSink *NetcdfOutputContext::createElementSink()
 {
     return impl_->createElementSink();
+}
+
+IPrintSink *NetcdfOutputContext::createRiverSink()
+{
+    return impl_->createRiverSink();
+}
+
+IPrintSink *NetcdfOutputContext::createLakeSink()
+{
+    return impl_->createLakeSink();
 }
 
 #endif /* _NETCDF_ON */

--- a/src/classes/NetcdfOutputContext.hpp
+++ b/src/classes/NetcdfOutputContext.hpp
@@ -24,6 +24,8 @@ public:
     ~NetcdfOutputContext();
 
     IPrintSink *createElementSink();
+    IPrintSink *createRiverSink();
+    IPrintSink *createLakeSink();
 
 private:
     struct Impl;


### PR DESCRIPTION
Closes #52

Summary:
- Add NetCDF output files `<prefix>.riv.nc` and `<prefix>.lake.nc` with `time` + object dimensions and id variables
- Route Print_Ctrl streams to element/river/lake sinks based on `n_all` (NumEle/NumRiv/NumLake)

Tests:
- `make clean && make shud`
- `make clean && make shud NETCDF=1`
