### PR TITLE
Fix lake area accumulation index

### DIFF
--- a/src/ModelData/MD_Lake.cpp
+++ b/src/ModelData/MD_Lake.cpp
@@ -62,7 +62,7 @@ void Model_Data::LakeInitialize(){
         for (int j = 0; j < NumEle ; j++){
             if(Ele[j].iLake == i + 1){ /* Lake element */
                 lake[i].NumEleLake++;
-                lake[i].area += Ele[i].area;
+                lake[i].area += Ele[j].area;
             }else{
                 for(int k = 0; k < 3; k++){
                     inabr = Ele[j].nabr[k] - 1;


### PR DESCRIPTION
Closes #40

Fix:
- In `Model_Data::LakeInitialize()`, accumulate lake area using `Ele[j].area` (element loop index) instead of `Ele[i].area` (lake index).

Tests:
- `make clean && make shud`
- `make clean && make shud NETCDF=1`
