### PR TITLE
ci: add GitHub Actions build workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  build-baseline:
+    name: Build (baseline)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y g++ make libsundials-dev
+
+      - name: Build
+        run: |
+          make clean
+          make shud SUNDIALS_DIR=/usr
+
+  build-netcdf:
+    name: Build (NETCDF=1)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y g++ make pkg-config libsundials-dev libnetcdf-dev
+
+      - name: Build
+        run: |
+          make clean
+          make shud SUNDIALS_DIR=/usr NETCDF=1

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,10 @@ Build
 DerivedData
 *.xcodeproj
 .github
+!.github/
+!.github/workflows/
+!.github/workflows/*.yml
+!.github/workflows/*.yaml
 SHUD.*
 .Rproj.user
 .DS_Store


### PR DESCRIPTION
Partially addresses #66 (adds CI checks; branch protection settings will be enabled after merge).\n\nSummary:\n- Add GitHub Actions workflow to build SHUD on Ubuntu (baseline + NETCDF=1).\n- Update .gitignore to allow committing .github/workflows/*.yml.\n\nTest plan:\n- GitHub Actions